### PR TITLE
PIKAChU integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ![GitHub Logo](https://github.com/OBrink/RanDepict/blob/main/RanDepict/logo_bg_white-1.png?raw=true)
 
-This repository contains RanDepict, an easy-to-use utility to generate a big variety of chemical structure depictions (random depiction styles and image augmentations) based on RDKit, CDK and Indigo.
+This repository contains RanDepict, an easy-to-use utility to generate a big variety of chemical structure depictions (random depiction styles and image augmentations) based on RDKit, CDK, Indigo and PIKAChU.
 
 ## Usage
 -  To use RanDepict, clone the repository to your local disk and make sure you install all the necessary requirements.

--- a/RanDepict/randepict.py
+++ b/RanDepict/randepict.py
@@ -906,7 +906,7 @@ class RandomDepictor:
         PIKAChU, RDKit and Indigo can run into problems if certain R group variables
         are present in the input molecule, and PIKAChU cannot handle isotopes.
         Hence, the depiction functions that use their functionalities need to
-        be removed based on the input smiles str.
+        be removed based on the input smiles str (if necessary).
 
         Args:
             smiles (str): SMILES representation of a molecule

--- a/RanDepict/randepict.py
+++ b/RanDepict/randepict.py
@@ -903,7 +903,7 @@ class RandomDepictor:
 
     def get_depiction_functions(self, smiles: str) -> List[Callable]:
         """
-        RDKit and Indigo can run into problems if certain R group variables
+        PIKAChU, RDKit and Indigo can run into problems if certain R group variables
         are present in the input molecule, and PIKAChU cannot handle isotopes.
         Hence, the depiction functions that use their functionalities need to
         be removed based on the input smiles str.
@@ -924,6 +924,9 @@ class RandomDepictor:
         if re.search('(\[\d\d\d?[A-Z])|(\[2H\])|(\[3H\])|(D)|(T)', smiles):
             depiction_functions.remove(self.depict_and_resize_pikachu)
         if self.has_r_group(smiles):
+            # PIKAChU only accepts \[[RXZ]\d*\]
+            if not re.search('\[[RXZ]\d*\]', smiles):
+                depiction_functions.remove(self.depict_and_resize_pikachu)
             # "R", "X", "Z" are not depicted by RDKit
             # The same is valid for X,Y,Z and a number
             if re.search('\[[RXZ]\]|\[[XYZ]\d+', smiles):

--- a/Tests/test_functions.py
+++ b/Tests/test_functions.py
@@ -279,6 +279,55 @@ class TestRandomDepictor:
             im = self.depictor.depict_and_resize_cdk(smiles)
             assert type(im) == np.ndarray
 
+    def test_depict_and_resize_pikachu(self):
+        # Assert that an image is returned with different types
+        # of input SMILES str
+        test_smiles = ['c1ccccc1',
+                       '[R1]C1=C([X23])C([R])=C([Z])C([X])=C1[R]']
+        for smiles in test_smiles:
+            im = self.depictor.depict_and_resize_pikachu(smiles)
+            assert type(im) == np.ndarray
+
+    def test_get_depiction_functions_normal(self):
+        # For a molecule without isotopes or R groups, all toolkits can be used 
+        observed = self.depictor.get_depiction_functions('c1ccccc1C(O)=O')
+        expected =  [
+            self.depictor.depict_and_resize_rdkit,
+            self.depictor.depict_and_resize_indigo,
+            self.depictor.depict_and_resize_cdk,
+            self.depictor.depict_and_resize_pikachu,
+        ]
+        assert observed == expected
+    def test_get_depiction_functions_isotopes(self):
+        # PIKAChU can't handle isotopes
+        observed = self.depictor.get_depiction_functions("[13CH3]N1C=NC2=C1C(=O)N(C(=O)N2C)C")
+        expected =  [
+            self.depictor.depict_and_resize_rdkit,
+            self.depictor.depict_and_resize_indigo,
+            self.depictor.depict_and_resize_cdk,
+        ]
+        assert observed == expected
+    def test_get_depiction_functions_R(self):
+        # RDKit depicts "R" without indices as '*' (which is not desired)
+        observed = self.depictor.get_depiction_functions("[R]N1C=NC2=C1C(=O)N(C(=O)N2C)C")
+        expected =  [
+            self.depictor.depict_and_resize_indigo,
+            self.depictor.depict_and_resize_cdk,
+            self.depictor.depict_and_resize_pikachu,
+            ]
+        assert observed == expected
+
+    def test_get_depiction_functions_X(self):
+        # RDKit and Indigo don't depict "X"
+        observed = self.depictor.get_depiction_functions("[X]N1C=NC2=C1C(=O)N(C(=O)N2C)C")
+        expected =  [
+            self.depictor.depict_and_resize_cdk,
+            self.depictor.depict_and_resize_pikachu,
+            ]
+        assert observed == expected
+
+        
+
     def test_smiles_to_mol_str(self):
         # Compare generated mol file str with reference string
         mol_str = self.depictor.smiles_to_mol_str("CC")

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "rdkit-pypi",
         "imagecorruptions",
         "pillow>=8.2.0",
+        'pikachu-chem @ git+https://github.com/OBrink/pikachu@accept-markush-structures#egg=pikachu-chem'
     ],
     package_data={"RanDepict": ["assets/*.*", "assets/*/*.*", "assets/*/*/*.*"]},
     classifiers=[


### PR DESCRIPTION
- Integration of the depiction functionalities that come with the cheminformatics toolkit PIKAChU
- PIKAChU can't handle isotopes right now -> ([13C])CCCC leads to the depiction of a molecule but the isotope is simply ignored
- The method random_depiction automatically handles the selection of the available depiction functions. In this case, a SMILES str that refers to a molecule with isotopes is never depicted using PIKAChU
- PIKAChU is **not** integrated in the methods that use depiction feature fingerprints (yet)