### PR TITLE
enable configuring depictor styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ bash Miniconda3-latest-Linux-x86_64.sh
 $ echo -e "channels:\n - conda-forge\n - nodefaults" > ~/.condarc
 $ conda update conda
 $ conda install conda-libmamba-solver
+$ conda config --set experimental_solver libmamba
 $ conda create --name RanDepict python=3.8
 $ conda activate RanDepict
 # pypi has rdkit so not necessary to install it using conda

--- a/RanDepict/__init__.py
+++ b/RanDepict/__init__.py
@@ -7,12 +7,12 @@ an easy-to-use utility to generate a big variety of
 chemical structure depictions (random depiction styles and image augmentations).
 
 
-Typical usage example:
-
-from RanDepict import RandomDepictor
-smiles = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
-with RandomDepictor() as depictor:
-    image = depictor(smiles)
+Example:
+--------
+>>> from RanDepict import RandomDepictor
+>>> smiles = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+>>> with RandomDepictor() as depictor:
+>>>    image = depictor(smiles)
 
 Have a look in the RanDepictNotebook.ipynb for more examples.
 
@@ -28,4 +28,4 @@ __all__ = [
 ]
 
 
-from .randepict import RandomDepictor, DepictionFeatureRanges, RandomMarkushStructureCreator
+from .randepict import RandomDepictor, RandomDepictorConfig, DepictionFeatureRanges, RandomMarkushStructureCreator

--- a/RanDepict/randepict.py
+++ b/RanDepict/randepict.py
@@ -168,13 +168,13 @@ class RandomDepictor:
             # TODO Needs documentation of config_file yaml format...
             """
             # randepict.yaml
-            RandomDepictor:
+            RandomDepictorConfig:
                 seed: 42
                 augment: False
                 styles:
                     - cdk
             """
-            config: RandomDepictorConfig = RandomDepictorConfig.from_config(OmegaConf.load(config_file)[cls.__name__])
+            config: RandomDepictorConfig = RandomDepictorConfig.from_config(OmegaConf.load(config_file)[RandomDepictorConfig.__name__])
         except Exception as e:
             print(f"Error loading from {config_file}. Make sure it has {cls.__name__} section. {e}")
             print("Using default config.")

--- a/RanDepict/randepict.py
+++ b/RanDepict/randepict.py
@@ -57,7 +57,7 @@ class RandomDepictor:
     the RGB image with the given chemical structure.
     """
 
-    def __init__(self, seed: int = 42, hand_drawn: bool = False, *, config: Path = None):
+    def __init__(self, seed: int = 42, hand_drawn: bool = False, *, config: RandomDepictorConfig = None):
         """
         Load the JVM only once, load superatom list (OSRA),
         set context for multiprocessing
@@ -75,18 +75,14 @@ class RandomDepictor:
         -------
 
         """
-        # TODO removing seed and hand_drawn args might break existing code
+        # TODO remove seed and hand_drawn args but watch out b/c might break existing code
         self.seed = seed
         self.hand_drawn = hand_drawn
 
-        self._config = RandomDepictorConfig()
-        if config:
-            try:
-                # TODO Needs documentation
-                self._config: RandomDepictorConfig = RandomDepictorConfig.from_config(OmegaConf.load(config)[self.__class__.__name__])
-            except Exception as e:
-                print(f"Error loading from {config}. Make sure it has {self.__class__.__name__} section. {e}")
-                print("Using default config.")
+        if config is None:
+            self._config = RandomDepictorConfig()
+        else:
+            self._config = config
 
         self.HERE = Path(__file__).resolve().parent.joinpath("assets")
 
@@ -134,6 +130,18 @@ class RandomDepictor:
             set_start_method("spawn")
         except RuntimeError:
             pass
+    
+    @classmethod
+    def from_config(cls, config_file: Path) -> 'RandomDepictor':
+        try:
+            # TODO Needs documentation
+            config: RandomDepictorConfig = RandomDepictorConfig.from_config(OmegaConf.load(config_file)[cls.__name__])
+        except Exception as e:
+            print(f"Error loading from {config}. Make sure it has {cls.__name__} section. {e}")
+            print("Using default config.")
+            config = RandomDepictorConfig()
+        return RandomDepictor(config=config)
+            
 
     def __call__(
         self,

--- a/RanDepict/randepict.py
+++ b/RanDepict/randepict.py
@@ -3030,7 +3030,7 @@ class DepictionFeatureRanges(RandomDepictor):
 
 
 class RandomMarkushStructureCreator:
-    def __init__(self, *, variables_list=None, max_index=21):
+    def __init__(self, *, variables_list=None, max_index=20):
         """
         RandomMarkushStructureCreator objects are instantiated with the desired
         inserted R group variables. Otherwise, "R", "X" and "Z" are used.
@@ -3043,7 +3043,7 @@ class RandomMarkushStructureCreator:
         else:
             self.r_group_variables = variables_list
 
-        self.potential_indices = range(max_index + 1)
+        self.potential_indices = range(1, max_index + 1)
 
     def generate_markush_structure_dataset(self, smiles_list: List[str]) -> List[str]:
         """

--- a/Tests/test_functions.py
+++ b/Tests/test_functions.py
@@ -1,6 +1,7 @@
 from RanDepict import RandomDepictor, DepictionFeatureRanges, RandomMarkushStructureCreator
 from rdkit import DataStructs
 import numpy as np
+from omegaconf import OmegaConf 
 
 import pytest
 
@@ -309,6 +310,39 @@ class TestRandomDepictorConstruction:
         with pytest.raises(ValueError) as excinfo:
             _ = RandomDepictorConfig(styles=[])
         assert 'Empty list' in str(excinfo.value)
+
+    def test_omega_config_rdc(self):
+        """Can create RandomDepictorConfig from yaml"""
+        s = """
+        # RandomDepictorConfig:
+            seed: 21
+            augment: False
+            styles:
+                - cdk
+        """
+        dict_config = OmegaConf.create(s)
+        rdc = RandomDepictorConfig.from_config(dict_config)
+        assert rdc.seed == 21
+        assert not rdc.hand_drawn
+        assert not rdc.augment
+        assert len(rdc.styles) == 1
+        assert 'cdk' in rdc.styles
+
+    def test_omega_config_rd(self, tmp_path):
+        """Can create RandomDepictor from yaml"""
+        s = """
+        RandomDepictorConfig:
+            seed: 21
+            augment: False
+            styles:
+                - cdk
+                - indigo
+        """
+        temp_config_file = tmp_path / "omg.yaml"
+        temp_config_file.write_text(s)
+        rd = RandomDepictor.from_config(config_file=temp_config_file)
+        assert rd.seed == 21
+        assert not rd.hand_drawn
 
 
 class TestRandomDepictor:

--- a/Tests/test_functions.py
+++ b/Tests/test_functions.py
@@ -321,7 +321,9 @@ class TestRandomDepictor:
             self.depictor.depict_and_resize_cdk,
             self.depictor.depict_and_resize_pikachu,
         ]
-        assert observed == expected
+        # symmetric_difference
+        difference = set(observed) ^ set(expected)
+        assert not difference
 
     def test_get_depiction_functions_isotopes(self):
         # PIKAChU can't handle isotopes
@@ -331,7 +333,8 @@ class TestRandomDepictor:
             self.depictor.depict_and_resize_indigo,
             self.depictor.depict_and_resize_cdk,
         ]
-        assert observed == expected
+        difference = set(observed) ^ set(expected)
+        assert not difference
 
     def test_get_depiction_functions_R(self):
         # RDKit depicts "R" without indices as '*' (which is not desired)
@@ -341,7 +344,8 @@ class TestRandomDepictor:
             self.depictor.depict_and_resize_cdk,
             self.depictor.depict_and_resize_pikachu,
         ]
-        assert observed == expected
+        difference = set(observed) ^ set(expected)
+        assert not difference
 
     def test_get_depiction_functions_X(self):
         # RDKit and Indigo don't depict "X"
@@ -350,7 +354,8 @@ class TestRandomDepictor:
             self.depictor.depict_and_resize_cdk,
             self.depictor.depict_and_resize_pikachu,
         ]
-        assert observed == expected
+        difference = set(observed) ^ set(expected)
+        assert not difference
 
     def test_smiles_to_mol_str(self):
         # Compare generated mol file str with reference string

--- a/Tests/test_functions.py
+++ b/Tests/test_functions.py
@@ -4,6 +4,8 @@ import numpy as np
 
 import pytest
 
+from RanDepict import RandomDepictorConfig
+
 class TestDepictionFeatureRanges:
     DFR = DepictionFeatureRanges()
 
@@ -271,6 +273,43 @@ class TestDepictionFeatureRanges:
         )
         assert list(picked_fingerprints) == ["A"] * 20
         assert corrected_n == 3
+
+class TestRandomDepictorConstruction:
+
+    def test_default_depicter(self):
+        """RandomDepictor default values should match that of the default RandomDepictorConfig"""
+        depicter =  RandomDepictor()
+        config = RandomDepictorConfig()
+        assert depicter.seed == config.seed
+        assert depicter.hand_drawn == config.hand_drawn
+
+    def test_init_param_override(self):
+        """Values passed to init should override defaults"""
+        config = RandomDepictorConfig()
+        assert config.seed != 21
+        assert not config.hand_drawn
+        depicter =  RandomDepictor(seed=21, hand_drawn=True)
+        assert depicter.seed == 21
+        assert depicter.hand_drawn
+
+    def test_config_override(self):
+        """Config passed to init should override defaults"""
+        config = RandomDepictorConfig(seed=21, hand_drawn=True)
+        depicter =  RandomDepictor(config=config)
+        assert depicter.seed == 21
+        assert depicter.hand_drawn
+
+    @pytest.mark.xfail(raises=ValueError) 
+    def test_invalid_style(self):
+        """Invalid style passed to config should raise exception"""
+        _ = RandomDepictorConfig(styles=["pio", "cdk"])
+    
+    def test_empty_style_list(self):
+        """Empty style list passed to config should raise exception"""
+        with pytest.raises(ValueError) as excinfo:
+            _ = RandomDepictorConfig(styles=[])
+        assert 'Empty list' in str(excinfo.value)
+
 
 class TestRandomDepictor:
     depictor = RandomDepictor()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,4 @@ rdkit-pypi
 imagecorruptions
 pillow>=8
 pikachu-chem>=1.0.7
+omegaconf==2.2.3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
         "imagecorruptions",
         "pillow>=8.2.0",
         "pikachu-chem>=1.0.7",
-        'omegaconf',
+        "omegaconf",
+        "typing-extensions;python_version<'3.8'"
     ],
     extras_require={
         "dev": ["tox", "pytest"],

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         "imagecorruptions",
         "pillow>=8.2.0",
         "pikachu-chem>=1.0.7",
+        'omegaconf',
     ],
     extras_require={
         "dev": ["tox", "pytest"],
@@ -36,8 +37,6 @@ setuptools.setup(
     package_data={"RanDepict": ["assets/*.*", "assets/*/*.*", "assets/*/*/*.*"]},
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -46,5 +45,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ setenv =
 whitelist_externals = python
 conda_deps =
     pytest
-    rdkit
 conda_channels =
     conda-forge
 commands = pytest --basetemp="{envtmpdir}" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,6 @@ requires = tox-conda
 setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
 whitelist_externals = python
-
-[testenv:py37]
 conda_deps =
     pytest
     rdkit


### PR DESCRIPTION
Here is how to use it.

```python
from RanDepict import RandomDepictor, RandomDepictorConfig

from pathlib import Path

smiles = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

cfg = RandomDepictorConfig(seed=24, styles=["cdk", "indigo"])
with RandomDepictor(config=cfg) as depictor:
    img1 = depictor(smiles)

"""
# omega_conf.yaml
RandomDepictorConfig:
   seed: 42
   augment: False
   styles:
       - cdk
"""

with RandomDepictor.from_config(config_file=Path('omega_conf.yaml')) as depictor:
   img2 = depictor(smiles)
```

Resolves #30 